### PR TITLE
Passing `active` parameter to getData

### DIFF
--- a/client_code/Tabulator/__init__.py
+++ b/client_code/Tabulator/__init__.py
@@ -241,7 +241,11 @@ class Tabulator(TabulatorTemplate):
         self.redraw()
         self._from_cache = True
 
-    def get_data(self, active=False):
+    def get_data(self, active="all"):
+        """
+        Returns the table data based on a Tabulator range row lookup value.
+        :active: Range row lookup. Valid values are: "visible", "active", "selected", "all"
+        """
         return [dict(row) for row in self._table.getData(active)]
 
     # properties

--- a/client_code/Tabulator/__init__.py
+++ b/client_code/Tabulator/__init__.py
@@ -241,10 +241,11 @@ class Tabulator(TabulatorTemplate):
         self.redraw()
         self._from_cache = True
 
+    def get_data(self, active=False):
+        return [dict(row) for row in self._table.getData(active)]
+
     # properties
-    @property
-    def data(self):
-        return [dict(row) for row in self._table.getData()]
+    data = property(get_data)
 
     @data.setter
     def data(self, value):


### PR DESCRIPTION
This allows restricting the data returned by using a [row range lookup](http://tabulator.info/docs/4.9/components#row-lookup) value: 

```
visible - Rows currently visible in the table viewport
active - Rows currently in the table (rows that pass current filters etc)
selected - Rows currently selected by the selection module (this includes not currently active rows)
all - All rows in the table regardless of filters
```

The parameter is named `active` as this is what it is called in the original source code: https://github.com/olifolkerd/tabulator/blob/75799201323ac2f4a912aeec9a9668494c2c3099/src/js/core.js#L976