### PR TITLE
check suspensions in places that can't suspend

### DIFF
--- a/client_code/Tabulator/_custom_modules.py
+++ b/client_code/Tabulator/_custom_modules.py
@@ -6,6 +6,7 @@ from anvil import Component
 from anvil.js import get_dom_node, report_exceptions
 from anvil.js.window import Function, document, window
 
+from ._helpers import assert_no_suspension
 from ._module_helpers import AbstractModule, tabulator_module
 
 
@@ -74,11 +75,11 @@ class AbstractCallableWrapper(AbstractModule):
             f = definition.get(option)
             if f is None or not callable(f):
                 continue
-            definition[option] = report_exceptions(self.wrap(f))
+            definition[option] = report_exceptions(self.wrap(assert_no_suspension(f)))
 
     @staticmethod
     def wrap(f):
-        raise NotImplementedError
+        return f
 
 
 @tabulator_module("formatterWrapper", moduleInitOrder=1)
@@ -115,6 +116,18 @@ class HeaderFilterFuncWrapper(AbstractCallableWrapper):
             return f(header_val, row_val, row_data, **params)
 
         return header_filter_func
+
+
+@tabulator_module("paramLookup", moduleInitOrder=1)
+class ParamLookupWrapper(AbstractCallableWrapper):
+    options = [
+        "headerFileterParams",
+        "titleFormatterParams",
+        "sorterParams",
+        "formatterParams",
+        "editorParams",
+        "headerFilterFuncParams",
+    ]
 
 
 def setup_editor(component, cell, onRendered, success, cancel):
@@ -313,6 +326,7 @@ custom_modules = [
         HeaderFilterWrapper,
         CustomDataLoader,
         QueryModule,
+        ParamLookupWrapper,
         ScrollPosMaintainer,
         OptionVerifier,
     )

--- a/client_code/Tabulator/_helpers.py
+++ b/client_code/Tabulator/_helpers.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2022 Stu Cork
 
+from functools import partial, wraps
+
 import anvil.js
-from anvil.js.window import Promise, RegExp, String, document, window
+from anvil.js.window import Function, Promise, RegExp, String, document, window
 
 from ._js_tabulator import TabulatorModule
 
@@ -127,3 +129,17 @@ def _spacing_property(a_b):
         setattr(self, "_spacing_" + a_b, value)
 
     return property(getter, setter, None, a_b)
+
+
+do_call = Function(
+    "fn",
+    "return Sk.misceval.callsimArray(Sk.ffi.toPy(fn));",
+)
+
+
+def assert_no_suspension(fn):
+    @wraps(fn)
+    def wrapped(*args, **kws):
+        return do_call(partial(fn, *args, **kws))
+
+    return wrapped


### PR DESCRIPTION
We basically can't suspend in:
custom formatters
custom editors
custom filters
Params lookup function

So we wrap the call in a skulptism that will raise an error if there's a suspension
