### PR TITLE
Removed deprecated _get_live_object_id call

### DIFF
--- a/client_code/Tabulator/_data_loader.py
+++ b/client_code/Tabulator/_data_loader.py
@@ -46,7 +46,7 @@ _ID = "_$id"
 
 
 def row_id_fallback(row, _field):
-    return anvil._get_live_object_id(row)
+    return row.get_id()
 
 
 _error_to_field = {KeyError: "key", AttributeError: "attribute", TableError: "column"}


### PR DESCRIPTION
Noticed this deprecated call being notified in the output

```Deprecated: _get_live_object_id is no longer required - call row.get_id() instead.```

Seemed simple enough for me to do. I didn't see a test suite to run, so I apologize, I didn't run any test.