### PR TITLE
Update _custom_modules.py 

### DIFF
--- a/client_code/Tabulator/_custom_modules.py
+++ b/client_code/Tabulator/_custom_modules.py
@@ -58,7 +58,7 @@ def cell_wrapper(f):
         return lambda cell, **params: f(cell=cell, **params)
     elif hasattr(f, "init_components"):
         # TODO - this could break if trying to use as both an editor and a headerFilter
-        return lambda cell, **params: f(item=dict(cell.getData()),cell=cell,**params)
+        return lambda cell, **params: f(item=dict(cell.getData()), cell=cell, **params)
     else:
         return lambda cell, **params: f(**params)
 


### PR DESCRIPTION
Add cell kw argument to functions so they are available to editor functions.

This change was driven by this conversation: 

https://anvil.works/forum/t/tabulator-which-column-am-i-in/16645?u=anthonys

It would be helpful to have the cell object , in some instances, when using a custom editor.